### PR TITLE
Add Geography Type to GeoAlchemy Backend

### DIFF
--- a/flask_admin/contrib/geoa/form.py
+++ b/flask_admin/contrib/geoa/form.py
@@ -4,7 +4,7 @@ from .fields import GeoJSONField
 
 
 class AdminModelConverter(SQLAAdminConverter):
-    @converts('Geometry')
+    @converts('Geography', 'Geometry')
     def convert_geom(self, column, field_args, **extra):
         field_args['geometry_type'] = column.type.geometry_type
         field_args['srid'] = column.type.srid


### PR DESCRIPTION
The current GeoAlchemy backend only works with geometry columns, and ignores geography columns (which are also supported by geoalchemy).  This 1-word fix adds support for geography columns.