### PR TITLE
Fix SQLAlchemy default sort order when column name is ambiguous.

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -716,7 +716,7 @@ class ModelView(BaseModelView):
 
             join_tables, attr = self._get_field_with_path(field)
 
-            return join_tables, field, direction
+            return join_tables, attr, direction
 
         return None
 


### PR DESCRIPTION
Instead of sorting on the raw column name, sort on the attribute we found. This fixes sorting for column names that are ambiguous due to table joins.