### PR TITLE
fix index_view csrf value rendering

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -111,7 +111,7 @@
                             <input type="hidden" name="id" value="{{ get_pk_value(row) }}"/>
                             <input type="hidden" name="url" value="{{ return_url }}"/>
                             {% if delete_form.csrf_token %}
-                            <input type="hidden" name="csrf_token" value="{{ delete_form.csrf_token() }}"/>
+                            <input name="csrf_token" type="hidden" value="{{ delete_form.csrf_token._value() }}"/>
                             {% endif %}
                             <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="{{ _gettext('Delete record') }}">
                                 <i class="icon-trash"></i>

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -111,7 +111,7 @@
                             <input type="hidden" name="id" value="{{ get_pk_value(row) }}"/>
                             <input type="hidden" name="url" value="{{ return_url }}"/>
                             {% if delete_form.csrf_token %}
-                            <input type="hidden" name="csrf_token" value="{{ delete_form.csrf_token() }}"/>
+                            <input name="csrf_token" type="hidden" value="{{ delete_form.csrf_token() }}"/>
                             {% endif %}
                             <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
                                 <span class="glyphicon glyphicon-trash"></span>

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -366,7 +366,7 @@ def test_csrf():
 
     def get_csrf_token(data):
         data = data.split('name="csrf_token" type="hidden" value="')[1]
-        token = data.split('">')[0]
+        token = data.split('"')[0]
         return token
 
     app, admin = setup()


### PR DESCRIPTION
This fixes an issue caused by my pull request #763. ```{{ delete_form.csrf_token() }}``` was rendering the entire field rather than just the value.

I made sure this works for both flask_wtf and wtforms2.