### PR TITLE
add menu item settings for AdminIndexView

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -415,12 +415,18 @@ class AdminIndexView(BaseView):
     """
     def __init__(self, name=None, category=None,
                  endpoint=None, url=None,
-                 template='admin/index.html'):
+                 template='admin/index.html',
+                 menu_class_name=None,
+                 menu_icon_type=None,
+                 menu_icon_value=None):
         super(AdminIndexView, self).__init__(name or babel.lazy_gettext('Home'),
                                              category,
                                              endpoint or 'admin',
                                              url or '/admin',
-                                             'static')
+                                             'static',
+                                             menu_class_name=menu_class_name,
+                                             menu_icon_type=menu_icon_type,
+                                             menu_icon_value=menu_icon_value)
         self._template = template
 
     @expose()


### PR DESCRIPTION
add `menu_class_name`, `menu_icon_type` and `menu_icon_value` for AdminIndexView's init function, so we can define icon & css class name for AdminIndex menu item.