### PR TITLE
Fix sorting on related columns

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -451,6 +451,9 @@ class ModelView(BaseModelView):
 
                     result[c] = column
 
+                    if join_tables:
+                        self._sortable_joins[c] = join_tables
+
             return result
 
     def init_search(self):

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -1343,6 +1343,31 @@ def test_default_sort():
     eq_(data[2].test1, 'c')
 
 
+def test_complex_sort():
+    app, db, admin = setup()
+    M1, M2 = create_models(db)
+
+    m1 = M1('b')
+    db.session.add(m1)
+    db.session.add(M2('c', model1=m1))
+
+    m2 = M1('a')
+    db.session.add(m2)
+    db.session.add(M2('c', model1=m2))
+
+    db.session.commit()
+
+    view = CustomModelView(M2, db.session,
+                           column_list = ['string_field', 'model1.test1'],
+                           column_sortable_list = ['model1.test1'])
+    admin.add_view(view)
+
+    client = app.test_client()
+
+    rv = client.get('/admin/model2/?sort=1')
+    eq_(rv.status_code, 200)
+
+
 def test_default_complex_sort():
     app, db, admin = setup()
     M1, M2 = create_models(db)
@@ -1365,6 +1390,7 @@ def test_default_complex_sort():
     eq_(len(data), 2)
     eq_(data[0].model1.test1, 'a')
     eq_(data[1].model1.test1, 'b')
+
 
 def test_extra_fields():
     app, db, admin = setup()


### PR DESCRIPTION
This fix might be related to issue #773. Sort was not producing the correct query for related columns.

The error looked like this:
```
OperationalError: (OperationalError) no such column: model1.test1 u'SELECT model2.id AS model2_id, model2.string_field AS model2_string_field, model2.int_field AS model2_int_field, model2.bool_field AS model2_bool_field, model2.enum_field AS model2_enum_field, model2.float_field AS model2_float_field, model2.model1_id AS model2_model1_id \nFROM model2 ORDER BY model1.test1\n LIMIT ? OFFSET ?' (20, 0)
```

I've also added a test which reproduced the issue.