### PR TITLE
Fix sorting and searching for relation objects

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1003,10 +1003,12 @@ class BaseModelView(BaseView, ActionsMixin):
         """
             Verify if column is sortable.
 
+            Not case-sensitive.
+
             :param name:
                 Column name.
         """
-        return name in self._sortable_columns
+        return name.lower() in (x.lower() for x in self._sortable_columns)
 
     def is_editable(self, name):
         """


### PR DESCRIPTION
Fix for the problem described in issue #773: https://github.com/mrjoes/flask-admin/issues/773#issuecomment-71593225

Now this will work as expected:
```
class ModelAdmin(sqla.ModelView):
    column_searchable_list = [Child.child_name]
```