### PR TITLE
Make SQLAlchemy AJAX filters case insensitive

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -58,7 +58,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
     def get_list(self, term, offset=0, limit=DEFAULT_PAGE_SIZE):
         query = self.session.query(self.model)
 
-        filters = (field.like(u'%%%s%%' % term) for field in self._cached_fields)
+        filters = (field.ilike(u'%%%s%%' % term) for field in self._cached_fields)
         query = query.filter(or_(*filters))
 
         return query.offset(offset).limit(limit).all()


### PR DESCRIPTION
This is much less surprising to the user than case sensitive searches.