### PR TITLE
Fix: allow clearing multiple-select fields (Issue #357)

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1245,7 +1245,7 @@ class BaseModelView(BaseView, ActionsMixin):
                 form._fields[field].raw_data == []]
 
         # Clear the corresponding model data for each of these fields.
-        if model:
+        if model and hasattr(model, '__iter__'):
             for cleared_select in cleared_selects:
                 if cleared_select in model:
                     if isinstance(model[cleared_select], list):

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1242,7 +1242,7 @@ class BaseModelView(BaseView, ActionsMixin):
         # Look for multiple-select fields that the user has cleared.
         cleared_selects = [form._fields[field].name for field in form._fields
             if form._fields[field].type.find('SelectMultiple') > -1 and
-            form._fields[field].raw_data == []]
+                form._fields[field].raw_data == []]
 
         # Clear the corresponding model data for each of these fields.
         for cleared_select in cleared_selects:

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1245,14 +1245,15 @@ class BaseModelView(BaseView, ActionsMixin):
                 form._fields[field].raw_data == []]
 
         # Clear the corresponding model data for each of these fields.
-        for cleared_select in cleared_selects:
-            if cleared_select in model:
-                if isinstance(model[cleared_select], list):
-                    # Clear the values one at a time to support list
-                    # implementations that watch changes on themselves.
-                    while model[cleared_select]:
-                        model[cleared_select].pop()
-                    model.save()
+        if model:
+            for cleared_select in cleared_selects:
+                if cleared_select in model:
+                    if isinstance(model[cleared_select], list):
+                        # Clear the values one at a time to support list
+                        # implementations that watch changes on themselves.
+                        while model[cleared_select]:
+                            model[cleared_select].pop()
+                        model.save()
 
     # URL generation helpers
     def _get_list_filter_args(self):


### PR DESCRIPTION
This is a fix for #357, where multiple-select fields cannot be cleared.

If a multiple-select form field is cleared of its items, it no longer has any selections, so the browser will not even include that field in the POST data. Due to this absence, the model data are not cleared as expected, and the items reappear in the form field.

This fix detects any multiple-select fields that the user has cleared, then clears the corresponding model data. It has been tested with MongoEngine.