### PR TITLE
Python 3 fix: FilterConverter sub-classing bug

### DIFF
--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -266,7 +266,7 @@ def convert(*args):
         See :mod:`flask.ext.admin.contrib.sqla.filters` for usage example.
     """
     def _inner(func):
-        func._converter_for = map(str.lower, args)
+        func._converter_for = list(map(str.lower, args))
         return func
     return _inner
 


### PR DESCRIPTION
A bunch of hairs pulled later I finally found the source for my problems.
FilterConverter wouldn't work properly if instantiated more than once in Python 3 because the return value of a `map()` call in the decorator `flask_admin.model.filters.convert`, which now returns a run-once generator. This would make the second instantiation's `FilterConverter.conv_XYZ._converter_for` empty, leading to a `Exception: Unsupported filter type X` exception.

So now it should be possible to do sub-classes of `FilterConverter` in Py3. At least it does for me.