### PR TITLE
remove not-visible fields from forms

### DIFF
--- a/flask_admin/form/rules.py
+++ b/flask_admin/form/rules.py
@@ -25,6 +25,13 @@ class BaseRule(object):
         self.rule_set = rule_set
         return self
 
+    @property
+    def visible_fields(self):
+        """
+            A list of visible fields for the given rule.
+        """
+        raise NotImplementedError()
+
     def __call__(self, form, form_opts=None, field_args={}):
         """
             Render rule.
@@ -68,6 +75,17 @@ class NestedRule(BaseRule):
         self.rules = rule_set.configure_rules(self.rules, self)
         return super(NestedRule, self).configure(rule_set, parent)
 
+    @property
+    def visible_fields(self):
+        """
+            Return visible fields for all child rules.
+        """
+        visible_fields = []
+        for rule in self.rules:
+            for field in rule.visible_fields:
+                visible_fields.append(field)
+        return visible_fields
+
     def __iter__(self):
         """
             Return rules.
@@ -110,6 +128,10 @@ class Text(BaseRule):
 
         self.text = text
         self.escape = escape
+
+    @property
+    def visible_fields(self):
+        return []
 
     def __call__(self, form, form_opts=None, field_args={}):
         if self.escape:
@@ -168,6 +190,10 @@ class Macro(BaseRule):
 
         return field
 
+    @property
+    def visible_fields(self):
+        return []
+
     def __call__(self, form, form_opts=None, field_args={}):
         """
             Render macro rule.
@@ -220,6 +246,10 @@ class Container(Macro):
         self.child_rule.configure(rule_set, self)
         return super(Container, self).configure(rule_set, parent)
 
+    @property
+    def visible_fields(self):
+        return self.child_rule.visible_fields
+
     def __call__(self, form, form_opts=None, field_args={}):
         """
             Render container.
@@ -257,6 +287,10 @@ class Field(Macro):
         """
         super(Field, self).__init__(render_field)
         self.field_name = field_name
+
+    @property
+    def visible_fields(self):
+        return [self.field_name]
 
     def __call__(self, form, form_opts=None, field_args={}):
         """
@@ -344,6 +378,14 @@ class RuleSet(object):
         """
         self.view = view
         self.rules = self.configure_rules(rules)
+
+    @property
+    def visible_fields(self):
+        visible_fields = []
+        for rule in self.rules:
+            for field in rule.visible_fields:
+                visible_fields.append(field)
+        return visible_fields
 
     def convert_string(self, value):
         """

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1477,6 +1477,10 @@ class BaseModelView(BaseView, ActionsMixin):
             return redirect(return_url)
 
         form = self.create_form()
+        if self._form_create_rules:
+            for field in form:
+                if field.name not in self._form_create_rules.visible_fields:
+                    form.__delitem__(field.name)
 
         if self.validate_form(form):
             if self.create_model(form):
@@ -1514,6 +1518,10 @@ class BaseModelView(BaseView, ActionsMixin):
             return redirect(return_url)
 
         form = self.edit_form(obj=model)
+        if self._form_edit_rules:
+            for field in form:
+                if field.name not in self._form_edit_rules.visible_fields:
+                    form.__delitem__(field.name)
 
         if self.validate_form(form):
             if self.update_model(form, model):


### PR DESCRIPTION
This is a fix for #686:  it prevents accidental data loss that can be caused when form fields are not included in form_rules.

Each form rule needs to define a property for `visible_fields` which returns all fields that the rule exposes.  I've covered all the basic form rules.

@mrjoes how does this look?  I'm open to any / all feedback.
