### PR TITLE
add menu item settings for FileAdmin

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -138,7 +138,7 @@ class FileAdmin(BaseView, ActionsMixin):
 
     def __init__(self, base_path, base_url=None,
                  name=None, category=None, endpoint=None, url=None,
-                 verify_path=True):
+                 verify_path=True, menu_class_name=None, menu_icon_type=None, menu_icon_value=None):
         """
             Constructor.
 
@@ -179,7 +179,9 @@ class FileAdmin(BaseView, ActionsMixin):
         if not op.exists(base_path):
             raise IOError('FileAdmin path "%s" does not exist or is not accessible' % base_path)
 
-        super(FileAdmin, self).__init__(name, category, endpoint, url)
+        super(FileAdmin, self).__init__(name, category, endpoint, url,
+                                        menu_class_name=menu_class_name, menu_icon_type=menu_icon_type,
+                                        menu_icon_value=menu_icon_value)
 
     def is_accessible_path(self, path):
         """


### PR DESCRIPTION
add `menu_class_name`, `menu_icon_type` and `menu_icon_value` for FileAdmin's init function, so we can define icon & css class name for FileAdmin menu item.