### PR TITLE
Catch import error on AppEngine.

### DIFF
--- a/flask_admin/contrib/__init__.py
+++ b/flask_admin/contrib/__init__.py
@@ -1,1 +1,4 @@
-__import__('pkg_resources').declare_namespace(__name__)
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass


### PR DESCRIPTION
```pkg_resources``` is unavailable in the AppEngine SDK so it throws an import error.

```
web_1 | ERROR    2015-03-26 15:07:03,331 wsgi.py:263] 
web_1 | Traceback (most recent call last):
web_1 |   File "/usr/local/google_appengine/google/appengine/runtime/wsgi.py", line 240, in Handle
web_1 |     handler = _config_handle.add_wsgi_middleware(self._LoadHandler())
web_1 |   File "/usr/local/google_appengine/google/appengine/runtime/wsgi.py", line 299, in _LoadHandler
web_1 |     handler, path, err = LoadObject(self._handler)
web_1 |   File "/usr/local/google_appengine/google/appengine/runtime/wsgi.py", line 85, in LoadObject
web_1 |     obj = __import__(path[0])
web_1 |   File "/code/main.py", line 3, in <module>
web_1 |     from flask.ext.admin.contrib.appengine import ModelView
web_1 |   File "/code/.lib/flask/exthook.py", line 81, in load_module
web_1 |     reraise(exc_type, exc_value, tb.tb_next)
web_1 |   File "/code/.lib/flask_admin/contrib/__init__.py", line 1, in <module>
web_1 |     __import__('pkg_resources').declare_namespace(__name__)
web_1 | ImportError: No module named pkg_resources
```