### PR TITLE
Always show flashed messages.

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1535,8 +1535,8 @@ class BaseModelView(BaseView, ActionsMixin):
 
         if self.validate_form(form):
             if self.create_model(form):
+                flash(gettext('Record was successfully created.'))
                 if '_add_another' in request.form:
-                    flash(gettext('Record was successfully created.'))
                     return redirect(request.url)
                 else:
                     return redirect(return_url)
@@ -1574,8 +1574,8 @@ class BaseModelView(BaseView, ActionsMixin):
 
         if self.validate_form(form):
             if self.update_model(form, model):
+                flash(gettext('Record was successfully saved.'))
                 if '_continue_editing' in request.form:
-                    flash(gettext('Record was successfully saved.'))
                     return redirect(request.url)
                 else:
                     return redirect(return_url)


### PR DESCRIPTION
Don't hide flashed messages when redirecting back to list view. It leaves the user confused as to whether
the operation was successful or not.