### PR TITLE
Fix display of form errors for bootstrap 3.

### DIFF
--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -77,7 +77,7 @@
 {# ---------------------- Forms -------------------------- #}
 {% macro render_field(form, field, kwargs={}, caller=None) %}
   {% set direct_error = h.is_field_error(field.errors) %}
-  <div class="form-group{{ ' error' if direct_error else '' }}">
+  <div class="form-group{{ ' has-error' if direct_error else '' }}">
     <label for="{{ field.id }}" class="col-md-2 control-label">{{ field.label.text }}
         {% if h.is_required_form_field(field) %}
           <strong style="color: red">&#42;</strong>
@@ -91,14 +91,14 @@
       {% if field.description %}
       <p class="help-block">{{ field.description }}</p>
       {% endif %}
+      {% if direct_error %}
+        <ul class="help-block input-errors">
+        {% for e in field.errors if e is string %}
+          <li>{{ e }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
     </div>
-    {% if direct_error %}
-      <ul{% if direct_error %} class="input-errors"{% endif %}>
-      {% for e in field.errors if e is string %}
-        <li>{{ e }}</li>
-      {% endfor %}
-      </ul>
-    {% endif %}
     {% if caller %}
       {{ caller(form, field, direct_error, kwargs) }}
     {% endif %}


### PR DESCRIPTION
This colours the input group using `has-errors` and lays out the errors nicely beneath the input box.