### PR TITLE
Warn on multi-column field in form. fixes #575

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -1,3 +1,5 @@
+import warnings
+
 from wtforms import fields, validators
 from sqlalchemy import Boolean, Column
 
@@ -158,7 +160,8 @@ class AdminModelConverter(ModelConverterBase):
                     columns = filter_foreign_columns(model.__table__, prop.columns)
 
                     if len(columns) > 1:
-                        raise TypeError('Can not convert multiple-column properties (%s.%s)' % (model, prop.key))
+                        warnings.warn('Can not convert multiple-column properties (%s.%s)' % (model, prop.key))
+                        return None
 
                     column = columns[0]
                 else:

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -393,6 +393,7 @@ class ModelView(BaseModelView):
 
                     if len(filtered) > 1:
                         warnings.warn('Can not convert multiple-column properties (%s.%s)' % (self.model, p.key))
+                        continue
 
                     column = filtered[0]
                 else:


### PR DESCRIPTION
With this change, you no longer need to ignore multi-column fields explicitly through column_exclude_list and form_excluded_columns.